### PR TITLE
Handle emergency scheduler actions

### DIFF
--- a/src/components/scheduler/EnhancedCommandControl.tsx
+++ b/src/components/scheduler/EnhancedCommandControl.tsx
@@ -232,7 +232,7 @@ export function EnhancedCommandControl() {
           name: `${actionName} - ${new Date().toISOString().split('T')[0]}`,
           server_ids: [], // Would be populated based on selection
           update_sequence: {
-            update_type: actionType,
+            update_type: actionType === 'security_patch' ? 'security_patch' : 'idrac',
             components: actionType === 'security_patch' ? ['BIOS', 'iDRAC', 'System CPLD'] : ['iDRAC'],
             rollout_strategy: 'parallel',
             priority: 'critical'
@@ -254,13 +254,15 @@ export function EnhancedCommandControl() {
       await supabase.functions.invoke('execute-remote-command', {
         body: {
           command: {
+            id: crypto.randomUUID(),
             name: actionName,
             target_type: 'datacenter',
             target_names: datacenters.map(dc => dc.name),
             command_type: actionType === 'security_patch' ? 'security_patch' : 'idrac_update',
             command_parameters: {
               emergency_mode: true,
-              priority: 'critical'
+              priority: 'critical',
+              update_category: actionType
             }
           },
           immediate_execution: true,


### PR DESCRIPTION
## Summary
- Ensure emergency scheduler commands create proper plans and send structured remote commands
- Expand execute-remote-command edge function to handle datacenter targets and emergency update types

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any and related lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d7c30b808320ad73c01130c11ddb