### PR TITLE
fix: add scroll for overflowing notification toasts

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse overflow-y-auto p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- allow toast viewport to scroll so multiple notifications stay visible

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any type errors)


------
https://chatgpt.com/codex/tasks/task_e_68c6dd66a4d48320b38cc479b9becef0