### PR TITLE
feat: add OME discovery and asset management UI

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -3,7 +3,17 @@ import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import { Header } from "@/components/layout/Header";
 import { Sidebar } from "@/components/layout/Sidebar";
 
-type PageType = "dashboard" | "global-inventory" | "enterprise" | "health" | "users" | "settings" | "alerts" | "vcenter" | "scheduler" | "discovery";
+type PageType =
+  | "dashboard"
+  | "global-inventory"
+  | "enterprise"
+  | "health"
+  | "users"
+  | "settings"
+  | "alerts"
+  | "vcenter"
+  | "scheduler"
+  | "discovery";
 
 export function AppLayout() {
   const navigate = useNavigate();

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
-  Server,
   Users,
   Settings,
   Activity,
@@ -15,7 +14,17 @@ import {
   Search
 } from "lucide-react";
 
-type PageType = "dashboard" | "global-inventory" | "enterprise" | "health" | "users" | "settings" | "alerts" | "vcenter" | "scheduler" | "discovery";
+type PageType =
+  | "dashboard"
+  | "global-inventory"
+  | "enterprise"
+  | "health"
+  | "users"
+  | "settings"
+  | "alerts"
+  | "vcenter"
+  | "scheduler"
+  | "discovery";
 
 interface SidebarProps {
   currentPage: PageType;
@@ -31,7 +40,7 @@ const menuItems: Array<{
 }> = [
   { id: "dashboard", label: "Dashboard", icon: Activity, roles: ["admin", "operator", "viewer"] },
   { id: "global-inventory", label: "Global Inventory", icon: Database, roles: ["admin", "operator", "viewer"] },
-  { id: "discovery", label: "Network Discovery", icon: Search, roles: ["admin", "operator"] },
+  { id: "discovery", label: "Discovery & Assets", icon: Search, roles: ["admin", "operator"] },
   { id: "vcenter", label: "vCenter Management", icon: Network, roles: ["admin", "operator"] },
   { id: "enterprise", label: "Infrastructure & Operations", icon: Building2, roles: ["admin", "operator"] },
   { id: "scheduler", label: "Command & Control", icon: Calendar, roles: ["admin", "operator"] },

--- a/src/components/ome/AssetsTable.tsx
+++ b/src/components/ome/AssetsTable.tsx
@@ -1,0 +1,111 @@
+import { useState, useMemo } from 'react';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { useHosts } from '@/pages/ome/hooks/useHosts';
+import type { Host } from '@/pages/ome/types';
+import { HostDetailDrawer } from './HostDetailDrawer';
+
+export function AssetsTable() {
+  const { data: hosts = [], clusters, tags } = useHosts();
+  const [query, setQuery] = useState('');
+  const [cluster, setCluster] = useState('all');
+  const [tag, setTag] = useState('all');
+  const [source, setSource] = useState('all');
+  const [selected, setSelected] = useState<Host | null>(null);
+
+  const filtered = useMemo(() => {
+    return hosts.filter((h) => {
+      const q = query.toLowerCase();
+      const matchesQ =
+        h.fqdn.toLowerCase().includes(q) ||
+        h.serviceTag?.toLowerCase().includes(q) ||
+        h.mgmtIp.includes(q);
+      if (!matchesQ) return false;
+      if (cluster !== 'all' && h.clusterMoid !== cluster) return false;
+      if (tag !== 'all' && !h.tags?.includes(tag)) return false;
+      const src = h.serviceTag || h.tags?.includes('ome') ? 'ome' : 'manual';
+      if (source !== 'all' && src !== source) return false;
+      return true;
+    });
+  }, [hosts, query, cluster, tag, source]);
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 mb-4">
+        <Input placeholder="Search" value={query} onChange={(e) => setQuery(e.target.value)} className="w-64" />
+        <Select value={source} onValueChange={setSource}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Source" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            <SelectItem value="ome">OME</SelectItem>
+            <SelectItem value="manual">Manual</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select value={cluster} onValueChange={setCluster}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Cluster" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            {clusters.map((c) => (
+              <SelectItem key={c} value={c}>
+                {c}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={tag} onValueChange={setTag}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="Tag" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All</SelectItem>
+            {tags.map((t) => (
+              <SelectItem key={t} value={t}>
+                {t}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Hostname</TableHead>
+            <TableHead>Mgmt IP</TableHead>
+            <TableHead>Model</TableHead>
+            <TableHead>Service Tag</TableHead>
+            <TableHead>Cluster</TableHead>
+            <TableHead>Mgmt Kind</TableHead>
+            <TableHead>Source</TableHead>
+            <TableHead>Tags</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filtered.map((h) => {
+            const src = h.serviceTag || h.tags?.includes('ome') ? 'OME' : 'Manual';
+            return (
+              <TableRow key={h.id} className="cursor-pointer" onClick={() => setSelected(h)}>
+                <TableCell>{h.fqdn}</TableCell>
+                <TableCell>{h.mgmtIp}</TableCell>
+                <TableCell>{h.model}</TableCell>
+                <TableCell>{h.serviceTag}</TableCell>
+                <TableCell>{h.clusterMoid}</TableCell>
+                <TableCell>{h.mgmtKind}</TableCell>
+                <TableCell>
+                  <Badge>{src}</Badge>
+                </TableCell>
+                <TableCell>{h.tags?.join(', ')}</TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      <HostDetailDrawer host={selected} onClose={() => setSelected(null)} />
+    </div>
+  );
+}

--- a/src/components/ome/DiscoveryPanel.tsx
+++ b/src/components/ome/DiscoveryPanel.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useToast } from '@/hooks/use-toast';
+import { useOme } from '@/pages/ome/hooks/useOme';
+import { RunStatsCards } from './RunStatsCards';
+import { DiscoveryPreviewTable } from './DiscoveryPreviewTable';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+
+export function DiscoveryPanel() {
+  const { connection, preview, run, schedule, cancel } = useOme();
+  const { toast } = useToast();
+  const [filter, setFilter] = useState('');
+  const [every, setEvery] = useState(60);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [previewData, setPreviewData] = useState<any | null>(null);
+
+  const disabled = !connection || preview.isPending || run.isPending || schedule.isPending || cancel.isPending;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2 items-end">
+        <Input
+          className="w-64"
+          placeholder="contains(DeviceName,'r740')"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        />
+        <Input
+          type="number"
+          min={5}
+          className="w-40"
+          value={every}
+          onChange={(e) => setEvery(parseInt(e.target.value, 10))}
+        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              disabled={disabled}
+              onClick={() =>
+                preview.mutate(filter, {
+                  onSuccess: (d) => {
+                    setPreviewData(d);
+                  },
+                  onError: (e: any) => toast({ variant: 'destructive', description: e.message }),
+                })
+              }
+            >
+              Preview
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Preview queries OME and shows a sample of what would be imported—no DB changes.
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="success"
+              disabled={disabled}
+              onClick={() => setConfirmOpen(true)}
+            >
+              Import Now
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Import Now upserts servers into your hosts table (de-dupe by Service Tag, then Mgmt IP).
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              disabled={disabled}
+              onClick={() =>
+                schedule.mutate(
+                  { everyMinutes: every, filter },
+                  {
+                    onSuccess: (d) => toast({ description: `Job ${d.jobId}` }),
+                    onError: (e: any) => toast({ variant: 'destructive', description: e.message }),
+                  }
+                )
+              }
+            >
+              Schedule Sync
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            Schedule runs periodic discovery via the server queue. You can cancel at any time.
+          </TooltipContent>
+        </Tooltip>
+        <Button
+          variant="destructive"
+          disabled={disabled}
+          onClick={() =>
+            cancel.mutate(undefined, {
+              onSuccess: () => toast({ description: 'Cancelled' }),
+              onError: (e: any) => toast({ variant: 'destructive', description: e.message }),
+            })
+          }
+        >
+          Cancel Schedule
+        </Button>
+      </div>
+      {previewData && (
+        <>
+          <RunStatsCards stats={{ ...previewData.stats, total: previewData.total, skipped: previewData.total }} />
+          <DiscoveryPreviewTable sample={previewData.sample} />
+        </>
+      )}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Import Now</DialogTitle>
+          </DialogHeader>
+          <p>This will upsert devices into your hosts table. Continue?</p>
+          <DialogFooter>
+            <Button
+              onClick={() =>
+                run.mutate(filter, {
+                  onSuccess: (d) => {
+                    toast({ description: 'Run started' });
+                    setConfirmOpen(false);
+                  },
+                  onError: (e: any) => toast({ variant: 'destructive', description: e.message }),
+                })
+              }
+            >
+              Continue
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/ome/DiscoveryPreviewTable.tsx
+++ b/src/components/ome/DiscoveryPreviewTable.tsx
@@ -1,0 +1,47 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableCaption,
+} from '@/components/ui/table';
+
+interface Row {
+  deviceName: string;
+  serviceTag: string;
+  networkAddress: string;
+  model: string;
+}
+
+export function DiscoveryPreviewTable({ sample }: { sample: Row[] }) {
+  if (!sample.length) return null;
+  return (
+    <div className="mt-4">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Device Name</TableHead>
+            <TableHead>Service Tag</TableHead>
+            <TableHead>Network Address</TableHead>
+            <TableHead>Model</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sample.map((row, i) => (
+            <TableRow key={i}>
+              <TableCell>{row.deviceName}</TableCell>
+              <TableCell>{row.serviceTag}</TableCell>
+              <TableCell>{row.networkAddress}</TableCell>
+              <TableCell>{row.model}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableCaption>
+          Preview shows a sample of up to 25 devices; actual run may affect more.
+        </TableCaption>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/ome/HostDetailDrawer.tsx
+++ b/src/components/ome/HostDetailDrawer.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import { Button } from '@/components/ui/button';
+import type { Host } from '@/pages/ome/types';
+import { discoverHost, omeResolveDevice } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import { useOme } from '@/pages/ome/hooks/useOme';
+
+interface Props {
+  host: Host | null;
+  onClose: () => void;
+}
+
+export function HostDetailDrawer({ host, onClose }: Props) {
+  const { toast } = useToast();
+  const { connection } = useOme();
+  const [omeId, setOmeId] = useState<number | null>(null);
+
+  if (!host) return null;
+
+  const handleDiscover = async () => {
+    try {
+      await discoverHost(host.id);
+      toast({ description: 'Discovery triggered' });
+    } catch (e: any) {
+      toast({ variant: 'destructive', description: e.message });
+    }
+  };
+
+  const handleResolve = async () => {
+    if (!connection) {
+      toast({ variant: 'destructive', description: 'Select an OME connection' });
+      return;
+    }
+    try {
+      const res = await omeResolveDevice(connection.id, host.id);
+      if (res.found) {
+        setOmeId(res.omeDeviceId!);
+        toast({ description: 'Device resolved' });
+      } else {
+        toast({ description: 'Device not found in OME' });
+      }
+    } catch (e: any) {
+      toast({ variant: 'destructive', description: e.message });
+    }
+  };
+
+  return (
+    <Drawer open={!!host} onOpenChange={(o) => !o && onClose()}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>{host.fqdn}</DrawerTitle>
+        </DrawerHeader>
+        <div className="p-4 space-y-1 text-sm">
+          <div>IP: {host.mgmtIp}</div>
+          <div>Model: {host.model}</div>
+          <div>Service Tag: {host.serviceTag}</div>
+          <div>Cluster: {host.clusterMoid}</div>
+          <div>Mgmt Kind: {host.mgmtKind}</div>
+        </div>
+        <DrawerFooter>
+          <Button onClick={handleDiscover}>Discover Capabilities</Button>
+          <Button onClick={handleResolve}>Resolve in OME</Button>
+          {omeId && connection && (
+            <Button asChild variant="secondary">
+              <a href={`${connection.baseUrl}/#Device/${omeId}`} target="_blank" rel="noreferrer">
+                Open in OME
+              </a>
+            </Button>
+          )}
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/components/ome/OmeConnectionManager.tsx
+++ b/src/components/ome/OmeConnectionManager.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { createOmeConnection } from '@/lib/api';
+import { useToast } from '@/hooks/use-toast';
+import { useOme } from '@/pages/ome/hooks/useOme';
+
+export function OmeConnectionManager() {
+  const { connection, setConnection } = useOme();
+  const { toast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [vaultPath, setVaultPath] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    try {
+      setLoading(true);
+      const urlValid = /^https?:\/\//.test(baseUrl);
+      const vaultValid = vaultPath.startsWith('env:');
+      if (!urlValid || !vaultValid) throw new Error('Invalid input');
+      const res = await createOmeConnection({ name, baseUrl, vaultPath });
+      setConnection({ id: res.id, name, baseUrl });
+      toast({ description: 'Connection saved' });
+      setOpen(false);
+    } catch (e: any) {
+      toast({ variant: 'destructive', description: e.message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <Select
+          value={connection?.id}
+          onValueChange={() => {}}
+          disabled={!connection}
+        >
+          <SelectTrigger className="w-64">
+            <SelectValue placeholder="No connection yet" />
+          </SelectTrigger>
+          <SelectContent>
+            {connection && (
+              <SelectItem value={connection.id}>{connection.name}</SelectItem>
+            )}
+          </SelectContent>
+        </Select>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button>Add OME Connection</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Add OME Connection</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <Label>Name</Label>
+                <Input value={name} onChange={(e) => setName(e.target.value)} />
+              </div>
+              <div className="space-y-2">
+                <Label>Base URL</Label>
+                <Input
+                  placeholder="https://ome.company.local"
+                  value={baseUrl}
+                  onChange={(e) => setBaseUrl(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Label>Vault Path</Label>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button variant="ghost" size="xs">?</Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Format: env:USER_ENV,PASS_ENV — server reads credentials from your API environment.
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <Input
+                  placeholder="env:OME_USER,OME_PASS"
+                  value={vaultPath}
+                  onChange={(e) => setVaultPath(e.target.value)}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button onClick={handleSubmit} disabled={loading}>
+                Save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/ome/RunStatsCards.tsx
+++ b/src/components/ome/RunStatsCards.tsx
@@ -1,0 +1,29 @@
+import { Card } from '@/components/ui/card';
+
+interface Props {
+  stats: { inserted?: number; updated?: number; skipped?: number; errors?: number; total?: number };
+}
+
+export function RunStatsCards({ stats }: Props) {
+  const items = [
+    { label: 'Inserted', value: stats.inserted ?? 0 },
+    { label: 'Updated', value: stats.updated ?? 0 },
+    { label: 'Skipped', value: stats.skipped ?? 0 },
+    { label: 'Errors', value: stats.errors ?? 0 },
+  ];
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-2 my-4">
+      {items.map((it) => (
+        <Card key={it.label} className="p-4 text-center">
+          <div className="text-sm text-muted-foreground">{it.label}</div>
+          <div className="text-xl font-bold">{it.value}</div>
+        </Card>
+      ))}
+      {stats.total !== undefined && (
+        <div className="col-span-2 md:col-span-4 text-center text-sm">
+          Total scanned: {stats.total}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/routing/AppRoutes.tsx
+++ b/src/components/routing/AppRoutes.tsx
@@ -5,14 +5,12 @@ import NotFound from "@/pages/NotFound";
 import { EnhancedDashboard } from "@/components/dashboard/EnhancedDashboard";
 import { ComprehensiveGlobalInventory } from "@/components/inventory/ComprehensiveGlobalInventory";
 import { EnhancedCommandControl } from "@/components/scheduler/EnhancedCommandControl";
-import AlertsEventsPage from "@/components/alerts/AlertsEventsPage";
 import EnhancedAlertsEventsPage from "@/components/alerts/EnhancedAlertsEventsPage";
 import VCenterManagement from "@/pages/VCenterManagement";
 import { HealthChecks } from "@/components/health/HealthChecks";
 import { UserManagement } from "@/components/users/UserManagement";
 import { SettingsPage } from "@/components/settings/SettingsPage";
-
-import { NetworkDiscovery } from "@/components/discovery/NetworkDiscovery";
+import Discovery from "@/pages/Discovery";
 import { EnterpriseManagement } from "@/components/enterprise/EnterpriseManagement";
 
 export function AppRoutes() {
@@ -22,7 +20,7 @@ export function AppRoutes() {
       <Route path="/" element={<AppLayout />}>
         <Route index element={<EnhancedDashboard />} />
         <Route path="inventory" element={<ComprehensiveGlobalInventory />} />
-        <Route path="discovery" element={<NetworkDiscovery />} />
+        <Route path="discovery" element={<Discovery />} />
         <Route path="scheduler" element={<EnhancedCommandControl />} />
         <Route path="enterprise" element={<EnterpriseManagement />} />
         <Route path="alerts" element={<EnhancedAlertsEventsPage />} />

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -37,3 +37,112 @@ export async function getPlanStatus(id: string) {
   });
   return res.json();
 }
+
+// OME connections
+export async function createOmeConnection(input: {
+  name: string;
+  baseUrl: string;
+  vaultPath: string;
+}): Promise<{ id: string }> {
+  const res = await fetch(`${BASE_URL}/ome/connections`, {
+    method: 'POST',
+    headers: authHeaders('application/json'),
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function listOmeRuns(
+  connectionId: string
+): Promise<{ runs: any[]; cacheSummary: any }> {
+  const res = await fetch(`${BASE_URL}/ome/${connectionId}/runs`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function omeDiscoverPreview(
+  connectionId: string,
+  filter?: string
+): Promise<{ runId: string; total: number; stats: any; sample: any[] }> {
+  const params = new URLSearchParams();
+  if (filter) params.set('filter', filter);
+  const res = await fetch(
+    `${BASE_URL}/ome/${connectionId}/discover/preview?${params.toString()}`,
+    { headers: authHeaders() }
+  );
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function omeDiscoverRun(
+  connectionId: string,
+  filter?: string
+): Promise<{ runId: string; stats: any }> {
+  const params = new URLSearchParams();
+  if (filter) params.set('filter', filter);
+  const res = await fetch(
+    `${BASE_URL}/ome/${connectionId}/discover/run?${params.toString()}`,
+    { method: 'POST', headers: authHeaders() }
+  );
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function omeSchedule(
+  connectionId: string,
+  everyMinutes: number,
+  filter?: string
+): Promise<{ scheduled: boolean; jobId: string }> {
+  const res = await fetch(`${BASE_URL}/ome/${connectionId}/schedule`, {
+    method: 'POST',
+    headers: authHeaders('application/json'),
+    body: JSON.stringify({ everyMinutes, filter }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function omeCancelSchedule(
+  connectionId: string
+): Promise<{ cancelled: boolean }> {
+  const res = await fetch(`${BASE_URL}/ome/${connectionId}/schedule`, {
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function omeResolveDevice(
+  connectionId: string,
+  hostId: string
+): Promise<{ found: boolean; omeDeviceId?: number }> {
+  const res = await fetch(
+    `${BASE_URL}/ome/${connectionId}/resolve/${hostId}`,
+    { method: 'POST', headers: authHeaders() }
+  );
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
+export async function listHosts(): Promise<
+  Array<{
+    id: string;
+    fqdn: string;
+    mgmtIp: string;
+    model?: string | null;
+    serviceTag?: string | null;
+    vcenterUrl?: string | null;
+    clusterMoid?: string | null;
+    hostMoid?: string | null;
+    mgmtKind?: string | null;
+    tags?: string[] | null;
+  }>
+> {
+  const res = await fetch(`${BASE_URL}/hosts`, { headers: authHeaders() });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}

--- a/src/pages/Discovery.tsx
+++ b/src/pages/Discovery.tsx
@@ -1,0 +1,21 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { NetworkDiscovery } from "@/components/discovery/NetworkDiscovery";
+import { OmePage } from "@/pages/ome/OmePage";
+
+export default function Discovery() {
+  return (
+    <Tabs defaultValue="network" className="space-y-6">
+      <TabsList>
+        <TabsTrigger value="network">Network Discovery</TabsTrigger>
+        <TabsTrigger value="ome">OME</TabsTrigger>
+      </TabsList>
+      <TabsContent value="network">
+        <NetworkDiscovery />
+      </TabsContent>
+      <TabsContent value="ome">
+        <OmePage />
+      </TabsContent>
+    </Tabs>
+  );
+}
+

--- a/src/pages/ome/AssetsTab.tsx
+++ b/src/pages/ome/AssetsTab.tsx
@@ -1,0 +1,11 @@
+import { OmeConnectionManager } from '@/components/ome/OmeConnectionManager';
+import { AssetsTable } from '@/components/ome/AssetsTable';
+
+export function AssetsTab() {
+  return (
+    <div className="space-y-4">
+      <OmeConnectionManager />
+      <AssetsTable />
+    </div>
+  );
+}

--- a/src/pages/ome/DiscoveryTab.tsx
+++ b/src/pages/ome/DiscoveryTab.tsx
@@ -1,0 +1,11 @@
+import { OmeConnectionManager } from '@/components/ome/OmeConnectionManager';
+import { DiscoveryPanel } from '@/components/ome/DiscoveryPanel';
+
+export function DiscoveryTab() {
+  return (
+    <div className="space-y-4">
+      <OmeConnectionManager />
+      <DiscoveryPanel />
+    </div>
+  );
+}

--- a/src/pages/ome/OmePage.tsx
+++ b/src/pages/ome/OmePage.tsx
@@ -1,0 +1,28 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { DiscoveryTab } from './DiscoveryTab';
+import { AssetsTab } from './AssetsTab';
+import { RunsTab } from './RunsTab';
+
+export function OmePage() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">OpenManage Discovery & Assets</h1>
+      <Tabs defaultValue="discovery">
+        <TabsList>
+          <TabsTrigger value="discovery">Discovery</TabsTrigger>
+          <TabsTrigger value="assets">Assets</TabsTrigger>
+          <TabsTrigger value="runs">Runs</TabsTrigger>
+        </TabsList>
+        <TabsContent value="discovery">
+          <DiscoveryTab />
+        </TabsContent>
+        <TabsContent value="assets">
+          <AssetsTab />
+        </TabsContent>
+        <TabsContent value="runs">
+          <RunsTab />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/src/pages/ome/RunsTab.tsx
+++ b/src/pages/ome/RunsTab.tsx
@@ -1,0 +1,41 @@
+import { OmeConnectionManager } from '@/components/ome/OmeConnectionManager';
+import { RunStatsCards } from '@/components/ome/RunStatsCards';
+import { useOme } from './hooks/useOme';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+
+export function RunsTab() {
+  const { runs } = useOme();
+  const data = runs.data?.runs ?? [];
+
+  return (
+    <div className="space-y-4">
+      <OmeConnectionManager />
+      {data.length === 0 && <p>No runs yet—try a Preview or Import.</p>}
+      {data.length > 0 && (
+        <>
+          <RunStatsCards stats={data[0].stats} />
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Started</TableHead>
+                <TableHead>Finished</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.slice(0, 50).map((r: any) => (
+                <TableRow key={r.id}>
+                  <TableCell>{r.startedAt}</TableCell>
+                  <TableCell>{r.finishedAt}</TableCell>
+                  <TableCell>{r.status}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <Button onClick={() => runs.refetch()}>Refresh</Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/ome/hooks/useHosts.ts
+++ b/src/pages/ome/hooks/useHosts.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { listHosts } from '@/lib/api';
+import type { Host } from '../types';
+
+export function useHosts() {
+  const query = useQuery<Host[]>({ queryKey: ['hosts'], queryFn: listHosts });
+
+  const clusters = useMemo(() => {
+    const set = new Set<string>();
+    (query.data ?? []).forEach((h) => {
+      if (h.clusterMoid) set.add(h.clusterMoid);
+    });
+    return Array.from(set);
+  }, [query.data]);
+
+  const tags = useMemo(() => {
+    const set = new Set<string>();
+    (query.data ?? []).forEach((h) => h.tags?.forEach((t) => set.add(t)));
+    return Array.from(set);
+  }, [query.data]);
+
+  const source = useMemo(() => {
+    const hosts = query.data ?? [];
+    return hosts.reduce(
+      (acc, h) => {
+        const isOme = !!h.serviceTag || h.tags?.includes('ome');
+        acc[isOme ? 'ome' : 'manual']++;
+        return acc;
+      },
+      { ome: 0, manual: 0 }
+    );
+  }, [query.data]);
+
+  return { ...query, clusters, tags, source };
+}

--- a/src/pages/ome/hooks/useOme.ts
+++ b/src/pages/ome/hooks/useOme.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import {
+  omeDiscoverPreview,
+  omeDiscoverRun,
+  omeSchedule,
+  omeCancelSchedule,
+  listOmeRuns,
+} from '@/lib/api';
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+export interface OmeConnection {
+  id: string;
+  name: string;
+  baseUrl: string;
+}
+
+const STORAGE_KEY = 'ome:selectedConnection';
+
+export function useOme() {
+  const [connection, setConnection] = useState<OmeConnection | null>(() => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  });
+
+  useEffect(() => {
+    if (connection) {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(connection));
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [connection]);
+
+  const preview = useMutation({
+    mutationFn: (filter?: string) => {
+      if (!connection) throw new Error('No connection');
+      return omeDiscoverPreview(connection.id, filter);
+    },
+  });
+
+  const run = useMutation({
+    mutationFn: (filter?: string) => {
+      if (!connection) throw new Error('No connection');
+      return omeDiscoverRun(connection.id, filter);
+    },
+  });
+
+  const schedule = useMutation({
+    mutationFn: (vars: { everyMinutes: number; filter?: string }) => {
+      if (!connection) throw new Error('No connection');
+      return omeSchedule(connection.id, vars.everyMinutes, vars.filter);
+    },
+  });
+
+  const cancel = useMutation({
+    mutationFn: () => {
+      if (!connection) throw new Error('No connection');
+      return omeCancelSchedule(connection.id);
+    },
+  });
+
+  const runs = useQuery({
+    queryKey: ['omeRuns', connection?.id],
+    queryFn: () => listOmeRuns(connection!.id),
+    enabled: !!connection,
+  });
+
+  return {
+    connection,
+    setConnection,
+    preview,
+    run,
+    schedule,
+    cancel,
+    runs,
+  };
+}

--- a/src/pages/ome/types.ts
+++ b/src/pages/ome/types.ts
@@ -1,0 +1,18 @@
+export type OmeRun = {
+  id: string;
+  startedAt: string;
+  finishedAt?: string;
+  status: 'running' | 'succeeded' | 'failed';
+  stats: Record<string, unknown>;
+};
+
+export type Host = {
+  id: string;
+  fqdn: string;
+  mgmtIp: string;
+  model?: string | null;
+  serviceTag?: string | null;
+  clusterMoid?: string | null;
+  mgmtKind?: string | null;
+  tags?: string[] | null;
+};


### PR DESCRIPTION
## Summary
- extend API client with OME discovery and host functions
- add OME connection manager and discovery panel with preview/run/schedule
- add assets table with host detail drawer and runs tab
- combine network and OME discovery into a single page

## Testing
- `npm run lint` *(fails: Unexpected any warnings across multiple files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6e8f84e4c832091999d563f1f91a4