### PR TITLE
docs: clarify OME sections on discovery page

### DIFF
--- a/src/pages/DiscoveryPage.tsx
+++ b/src/pages/DiscoveryPage.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Button } from '@/components/ui/button';
 import { NetworkDiscovery } from '@/components/discovery/NetworkDiscovery';
 import { DiscoveryTab as OmeDiscoveryTab } from '@/pages/ome/DiscoveryTab';
 import { AssetsTab } from '@/pages/ome/AssetsTab';
@@ -11,24 +10,48 @@ export function DiscoveryPage() {
   const [activeTab, setActiveTab] = useState('network');
 
   const tabs = [
-    { id: 'network', label: 'Network Discovery', icon: Wifi },
-    { id: 'ome-discovery', label: 'OME Discovery', icon: Server },
-    { id: 'ome-assets', label: 'OME Assets', icon: Database },
-    { id: 'ome-runs', label: 'OME Runs', icon: Activity },
+    {
+      id: 'network',
+      label: 'Network Discovery',
+      icon: Wifi,
+      description:
+        'Discover Dell servers with iDRAC access across your network infrastructure',
+    },
+    {
+      id: 'ome-discovery',
+      label: 'OME Discovery',
+      icon: Server,
+      description:
+        'Initiate device discovery through an OpenManage Enterprise instance',
+    },
+    {
+      id: 'ome-assets',
+      label: 'OME Assets',
+      icon: Database,
+      description:
+        'Review and manage assets synced from OpenManage Enterprise',
+    },
+    {
+      id: 'ome-runs',
+      label: 'OME Runs',
+      icon: Activity,
+      description:
+        'Track discovery job history and status from OpenManage Enterprise',
+    },
   ];
+
+  const active = tabs.find((t) => t.id === activeTab) ?? tabs[0];
 
   return (
     <div className="space-y-8">
       {/* Page Header */}
       <div className="flex items-center gap-4">
         <div className="w-12 h-12 bg-gradient-primary rounded-xl flex items-center justify-center">
-          <Wifi className="w-6 h-6 text-white" />
+          <active.icon className="w-6 h-6 text-white" />
         </div>
         <div>
-          <h1 className="text-4xl font-bold text-gradient">Network Discovery</h1>
-          <p className="text-muted-foreground text-lg">
-            Discover Dell servers with iDRAC access across your network infrastructure
-          </p>
+          <h1 className="text-4xl font-bold text-gradient">{active.label}</h1>
+          <p className="text-muted-foreground text-lg">{active.description}</p>
         </div>
       </div>
 

--- a/src/pages/ome/AssetsTab.tsx
+++ b/src/pages/ome/AssetsTab.tsx
@@ -4,6 +4,10 @@ import { AssetsTable } from '@/components/ome/AssetsTable';
 export function AssetsTab() {
   return (
     <div className="space-y-4">
+      <p className="text-muted-foreground">
+        Browse hardware assets gathered from your OpenManage Enterprise
+        instance.
+      </p>
       <OmeConnectionManager />
       <AssetsTable />
     </div>

--- a/src/pages/ome/DiscoveryTab.tsx
+++ b/src/pages/ome/DiscoveryTab.tsx
@@ -4,6 +4,10 @@ import { DiscoveryPanel } from '@/components/ome/DiscoveryPanel';
 export function DiscoveryTab() {
   return (
     <div className="space-y-4">
+      <p className="text-muted-foreground">
+        Connect to OpenManage Enterprise and launch discovery jobs to import
+        devices into your inventory.
+      </p>
       <OmeConnectionManager />
       <DiscoveryPanel />
     </div>

--- a/src/pages/ome/RunsTab.tsx
+++ b/src/pages/ome/RunsTab.tsx
@@ -10,6 +10,9 @@ export function RunsTab() {
 
   return (
     <div className="space-y-4">
+      <p className="text-muted-foreground">
+        Review recent discovery runs executed in OpenManage Enterprise.
+      </p>
       <OmeConnectionManager />
       {data.length === 0 && <p>No runs yet—try a Preview or Import.</p>}
       {data.length > 0 && (


### PR DESCRIPTION
## Summary
- add dynamic heading and descriptions for Network Discovery and OME tabs
- document OME discovery, assets, and run history tabs with introductory text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 380 problems, mostly unrelated)*

------
https://chatgpt.com/codex/tasks/task_e_68c70553a3988320aa245914f51136fb