### PR TITLE
fix dashboard config import/export issue

### DIFF
--- a/src/components/dashboard/DashboardConfig.tsx
+++ b/src/components/dashboard/DashboardConfig.tsx
@@ -246,3 +246,4 @@ export function DashboardConfig({ isOpen, onClose, widgets, onUpdateWidgets }: D
 }
 
 export { DEFAULT_WIDGETS };
+export default DashboardConfig;

--- a/src/components/dashboard/ModernEnterpriseDashboard.tsx
+++ b/src/components/dashboard/ModernEnterpriseDashboard.tsx
@@ -7,7 +7,7 @@ import { useSystemEvents } from '@/hooks/useSystemEvents';
 import { useVCenterService } from '@/hooks/useVCenterService';
 import { useFirmwarePackages } from '@/hooks/useFirmwarePackages';
 import { useMaintenanceWindows } from '@/hooks/useMaintenanceWindows';
-import { DashboardConfig, DashboardWidget, DEFAULT_WIDGETS } from './DashboardConfig';
+import DashboardConfig, { type DashboardWidget, DEFAULT_WIDGETS } from './DashboardConfig';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';


### PR DESCRIPTION
## Summary
- export DashboardConfig as default to ensure valid component usage
- consume DashboardConfig via default import in ModernEnterpriseDashboard

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c70cdac4588320a6db07090de0fb9c