### PR TITLE
Add Redfish update modes with manual UI and resilient polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Unreleased
+
+- Added support for selectable update modes (latest catalog, specific URL, multipart upload) with Redfish/RACADM orchestration fallback.
+- Hardened TLS handling with optional trusted CA bundles and unified Redfish task polling with reboot resilience and inventory verification.
+- Introduced manual update UI with progress reporting and firmware upload endpoint for multipart updates.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -7,11 +7,13 @@
       "name": "@idrac/api",
       "dependencies": {
         "@fastify/cors": "^11.1.0",
+        "@fastify/multipart": "^9.2.1",
         "@fastify/swagger": "^8",
         "@fastify/swagger-ui": "^1",
         "bullmq": "^5",
         "drizzle-orm": "^0.33",
         "fastify": "^4",
+        "form-data": "^4.0.0",
         "ioredis": "^5",
         "pg": "^8",
         "pino": "^9",
@@ -936,6 +938,12 @@
         "fast-uri": "^2.0.0"
       }
     },
+    "node_modules/@fastify/busboy": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
     "node_modules/@fastify/cors": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.1.0.tgz",
@@ -962,6 +970,22 @@
       "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
       "license": "MIT"
     },
+    "node_modules/@fastify/deepmerge": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-3.1.0.tgz",
+      "integrity": "sha512-lCVONBQINyNhM6LLezB6+2afusgEYR4G8xenMsfe+AT+iZ7Ca6upM5Ha8UkZuYSnuMw3GWl/BiPXnLMi/gSxuQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/error": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-3.4.1.tgz",
@@ -985,6 +1009,67 @@
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       }
+    },
+    "node_modules/@fastify/multipart": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/multipart/-/multipart-9.2.1.tgz",
+      "integrity": "sha512-U4221XDMfzCUtfzsyV1/PkR4MNgKI0158vUUyn/oF2Tl6RxMc+N7XYLr5fZXQiEC+Fmw5zFaTjxsTGTgtDtK+g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^3.0.0",
+        "@fastify/deepmerge": "^3.0.0",
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "secure-json-parse": "^4.0.0"
+      }
+    },
+    "node_modules/@fastify/multipart/node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/multipart/node_modules/fastify-plugin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.0.1.tgz",
+      "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/multipart/node_modules/secure-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
+      "integrity": "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/@fastify/send": {
       "version": "2.1.0",
@@ -1221,6 +1306,12 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1321,6 +1412,19 @@
         "uuid": "^9.0.0"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -1335,6 +1439,18 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1393,6 +1509,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -1573,6 +1698,20 @@
         }
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -1580,6 +1719,51 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1807,6 +1991,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1835,6 +2035,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -1868,6 +2114,57 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/help-me": {
@@ -2035,6 +2332,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -2045,6 +2351,27 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {

--- a/api/package.json
+++ b/api/package.json
@@ -14,11 +14,13 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.1.0",
+    "@fastify/multipart": "^9.2.1",
     "@fastify/swagger": "^8",
     "@fastify/swagger-ui": "^1",
     "bullmq": "^5",
     "drizzle-orm": "^0.33",
     "fastify": "^4",
+    "form-data": "^4.0.0",
     "ioredis": "^5",
     "pg": "^8",
     "pino": "^9",

--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -20,6 +20,11 @@ const envSchema = z.object({
     .transform(v => v !== 'false'),
 
   CA_BUNDLE_PATH: z.string().optional().default(''),
+  IDRAC_CA_PEM: z.string().optional().default(''),
+
+  DELL_CATALOG_URL: z.string().default('https://downloads.dell.com/catalog/Catalog.xml.gz'),
+
+  IDRAC_UPDATE_TIMEOUT_MIN: z.coerce.number().default(90),
 
   // Defaults; per-host overrides live in DB/credentials
   VCENTER_URL: z.string().optional().default(''),
@@ -27,6 +32,7 @@ const envSchema = z.object({
   VCENTER_PASSWORD: z.string().optional().default(''),
 
   // Runner binaries
+  RACADM_BIN: z.string().default(process.env.RACADM_PATH ?? 'racadm'),
   RACADM_PATH: z.string().default('racadm'),
   IPMITOOL_PATH: z.string().default('ipmitool')
 });

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,7 @@ import './lib/http/tls.js'; // set Undici TLS agent early
 import Fastify from 'fastify';
 import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
+import multipart from '@fastify/multipart';
 import cors from '@fastify/cors';
 import config from './config/index.js';
 import hostsRoutes from './routes/hosts.js';
@@ -9,12 +10,14 @@ import plansRoutes from './routes/plans.js';
 import healthRoutes from './routes/health.js';
 import vcentersRoutes from './routes/vcenters.js';
 import systemRoutes from './routes/system.js';
+import uploadsRoutes from './routes/uploads.js';
 
 const app = Fastify({ logger: { transport: { target: 'pino-pretty' } } });
 
 await app.register(cors, { origin: true, credentials: true });
 await app.register(swagger, { openapi: { info: { title: 'iDRAC Orchestrator API', version: '1.0.0' } } });
 await app.register(swaggerUi, { routePrefix: '/docs' });
+await app.register(multipart);
 
 // Simple API key auth
 app.addHook('preHandler', (req, reply, done) => {
@@ -36,6 +39,7 @@ app.register(plansRoutes);
 app.register(healthRoutes);
 app.register(vcentersRoutes);
 app.register(systemRoutes);
+app.register(uploadsRoutes);
 
 // Start worker
 if (process.env.DISABLE_WORKER !== 'true') {

--- a/api/src/lib/racadm/index.ts
+++ b/api/src/lib/racadm/index.ts
@@ -1,24 +1,107 @@
 import { spawn } from 'node:child_process';
-import config from '../../config/index.js';
 
-function run(cmd: string, args: string[], timeoutMs = 15 * 60_000) {
+export interface RacadmCreds { username: string; password: string; }
+
+export type RacadmLoggerEvent =
+  | { type: 'start'; command: string; args: string[] }
+  | { type: 'stdout'; chunk: string }
+  | { type: 'stderr'; chunk: string }
+  | { type: 'exit'; code: number };
+
+export type RacadmLogger = (event: RacadmLoggerEvent) => void;
+
+export interface RacadmAutoUpdateResult {
+  code: number;
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  durationMs: number;
+  successMessage?: string;
+  failureReason?: string;
+}
+
+export interface RacadmAutoUpdateOptions {
+  timeoutMs?: number;
+  logger?: RacadmLogger;
+}
+
+const DEFAULT_TIMEOUT_MS = 30 * 60_000;
+
+function getBinary() {
+  return process.env.RACADM_BIN ?? process.env.RACADM_PATH ?? 'racadm';
+}
+
+function runRacadm(args: string[], options: RacadmAutoUpdateOptions) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const logger = options.logger;
   return new Promise<{ code: number; stdout: string; stderr: string }>((resolve, reject) => {
+    const cmd = getBinary();
     const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-    let stdout = '', stderr = '';
-    const t = setTimeout(() => { child.kill('SIGKILL'); reject(new Error('racadm timeout')); }, timeoutMs);
-    child.stdout.on('data', d => (stdout += d));
-    child.stderr.on('data', d => (stderr += d));
-    child.on('error', reject);
-    child.on('close', code => { clearTimeout(t); resolve({ code: code ?? 1, stdout, stderr }); });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('racadm timeout'));
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      logger?.({ type: 'stdout', chunk: text });
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      stderr += text;
+      logger?.({ type: 'stderr', chunk: text });
+    });
+    child.on('error', err => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', code => {
+      clearTimeout(timer);
+      logger?.({ type: 'exit', code: code ?? 1 });
+      resolve({ code: code ?? 1, stdout, stderr });
+    });
   });
 }
 
-export async function fwupdate(host: string, imageServer: string) {
-  const user = process.env.IDRAC_USER ?? '';
-  const pass = process.env.IDRAC_PASS ?? '';
-  if (!user || !pass) throw new Error('RACADM needs IDRAC_USER/IDRAC_PASS env');
-  const args = ['-r', host, '-u', user, '-p', pass, 'fwupdate', '-g', '-u', '-a', imageServer];
-  const { code, stderr } = await run(config.RACADM_PATH, args);
-  if (code !== 0) throw new Error(`racadm fwupdate failed: ${stderr}`);
-  return { result: 'queued' };
+function sanitizeArgs(host: string, creds: RacadmCreds, repoUrl: string) {
+  return ['-r', host, '-u', creds.username, '-p', '********', 'fwupdate', '-g', '-u', '-a', repoUrl];
+}
+
+function detectFailure(stdout: string, stderr: string) {
+  const combined = `${stdout}\n${stderr}`;
+  const match = combined.match(/(error|fail(?:ed)?|invalid|not supported)[^\n]*/i);
+  return match ? match[0].trim() : undefined;
+}
+
+function detectSuccess(stdout: string) {
+  const match = stdout.match(/(success|completed)[^\n]*/i);
+  return match ? match[0].trim() : undefined;
+}
+
+export async function racadmAutoUpdate(
+  host: string,
+  creds: RacadmCreds,
+  repoUrl: string,
+  options: RacadmAutoUpdateOptions = {}
+): Promise<RacadmAutoUpdateResult> {
+  if (!creds.username || !creds.password) {
+    throw new Error('racadm credentials missing username or password');
+  }
+  const args = ['-r', host, '-u', creds.username, '-p', creds.password, 'fwupdate', '-g', '-u', '-a', repoUrl];
+  const logger = options.logger;
+  if (logger) {
+    logger({ type: 'start', command: getBinary(), args: sanitizeArgs(host, creds, repoUrl) });
+  }
+  const startedAt = Date.now();
+  const { code, stdout, stderr } = await runRacadm(args, options);
+  const durationMs = Date.now() - startedAt;
+
+  const failureReason = detectFailure(stdout, stderr);
+  const successMessage = detectSuccess(stdout);
+  const success = code === 0 && !failureReason;
+
+  return { code, success, stdout, stderr, durationMs, successMessage, failureReason };
 }

--- a/api/src/lib/redfish/client.ts
+++ b/api/src/lib/redfish/client.ts
@@ -1,21 +1,220 @@
-export interface IdracCreds { username: string; password: string; }
-const auth = (c: IdracCreds) => 'Basic ' + Buffer.from(`${c.username}:${c.password}`).toString('base64');
+import fs from 'node:fs';
+import https from 'node:https';
+import path from 'node:path';
+import type { Readable } from 'node:stream';
+import FormData from 'form-data';
 
-export async function simpleUpdate(idracHost: string, creds: IdracCreds, imageUri: string) {
-  const url = `https://${idracHost}/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate`;
-  const res = await fetch(url, {
+export interface IdracCreds { username: string; password: string; }
+export const authHeader = (c: IdracCreds) => 'Basic ' + Buffer.from(`${c.username}:${c.password}`).toString('base64');
+
+export const insecureAgent = new https.Agent({ rejectUnauthorized: false });
+
+let cachedAgent: https.Agent | null = null;
+let cachedKey: string | null = null;
+
+function loadCaBundle(value: string): string {
+  if (value.includes('-----BEGIN')) return value;
+  const filePath = path.resolve(value);
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read IDRAC_CA_PEM at ${filePath}: ${message}`);
+  }
+}
+
+export function getIdracAgent(): https.Agent {
+  const caSetting = process.env.IDRAC_CA_PEM ?? '';
+  const key = caSetting || '__insecure__';
+  if (cachedAgent && cachedKey === key) return cachedAgent;
+
+  if (!caSetting.trim()) {
+    cachedAgent = insecureAgent;
+    cachedKey = key;
+    return cachedAgent;
+  }
+
+  const ca = loadCaBundle(caSetting.trim());
+  cachedAgent = new https.Agent({ ca, rejectUnauthorized: true });
+  cachedKey = key;
+  return cachedAgent;
+}
+
+type RedfishRequestInit = RequestInit & { agent?: https.Agent };
+
+export function redfishFetch(input: string | URL, init: RequestInit = {}) {
+  const opts: RedfishRequestInit = { ...init, agent: getIdracAgent() };
+  return fetch(input, opts as RequestInit);
+}
+
+export const DEFAULT_DELL_CATALOG_URL = process.env.DELL_CATALOG_URL ?? 'https://downloads.dell.com/catalog/Catalog.xml.gz';
+
+export class RedfishError extends Error {
+  constructor(message: string, public status: number, public body: unknown) {
+    super(`${message} (status ${status})`);
+    this.name = 'RedfishError';
+  }
+}
+
+export class RedfishActionMissingError extends RedfishError {
+  constructor(public action: string) {
+    super(`Redfish action ${action} not supported`, 400, null);
+    this.name = 'RedfishActionMissingError';
+  }
+}
+
+export function normalizeBaseUrl(idracHost: string) {
+  const trimmed = idracHost.replace(/\s+/g, '').replace(/\/+$/, '');
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
+export async function readResponseBody(res: Response): Promise<unknown> {
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export function resolveLocation(baseUrl: string, raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+    return new URL(raw, base).toString();
+  } catch {
+    return null;
+  }
+}
+
+export async function simpleUpdate(idracHost: string, creds: IdracCreds, imageUri: string, targets?: string[]) {
+  const baseUrl = normalizeBaseUrl(idracHost);
+  const url = `${baseUrl}/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate`;
+  const proto = imageUri.startsWith('https://') ? 'HTTPS' : 'HTTP';
+  const payload: Record<string, unknown> = { ImageURI: imageUri, TransferProtocol: proto };
+  if (targets?.length) payload.Targets = targets;
+
+  const res = await redfishFetch(url, {
     method: 'POST',
-    headers: { 'content-type': 'application/json', authorization: auth(creds) },
-    body: JSON.stringify({ ImageURI: imageUri, TransferProtocol: 'HTTP', Targets: [] })
+    headers: { 'content-type': 'application/json', authorization: authHeader(creds) },
+    body: JSON.stringify(payload)
   });
-  if (!res.ok) throw new Error(`SimpleUpdate failed: ${res.status}`);
-  const loc = res.headers.get('location') || '';
-  const jobLocation = loc.startsWith('http') ? loc : `https://${idracHost}${loc}`;
-  return { jobLocation };
+  const body = await readResponseBody(res);
+  if (res.status >= 400) throw new RedfishError('SimpleUpdate failed', res.status, body);
+  const taskLocation = resolveLocation(baseUrl, res.headers.get('location'));
+  return { status: res.status, body, taskLocation, jobLocation: taskLocation };
+}
+
+interface InstallFromRepositoryOptions {
+  installUpon?: 'Immediate' | 'OnReset';
+  updateParameters?: Record<string, unknown>;
+}
+
+export async function installFromRepository(
+  idracHost: string,
+  creds: IdracCreds,
+  repoUrl?: string,
+  options: InstallFromRepositoryOptions = {}
+) {
+  const baseUrl = normalizeBaseUrl(idracHost);
+  const serviceUrl = `${baseUrl}/redfish/v1/UpdateService`;
+  const serviceRes = await redfishFetch(serviceUrl, { headers: { authorization: authHeader(creds) } });
+  if (!serviceRes.ok) {
+    const body = await readResponseBody(serviceRes);
+    throw new RedfishError('Failed to query UpdateService', serviceRes.status, body);
+  }
+  const service = await serviceRes.json() as any;
+  const actionKey = '#UpdateService.InstallFromRepository';
+  if (!service?.Actions?.[actionKey]) {
+    throw new RedfishActionMissingError(actionKey);
+  }
+
+  const payload = {
+    Repository: repoUrl ?? DEFAULT_DELL_CATALOG_URL,
+    InstallUpon: options.installUpon ?? 'Immediate',
+    UpdateParameters: options.updateParameters ?? {}
+  };
+
+  const actionUrl = `${serviceUrl}/Actions/UpdateService.InstallFromRepository`;
+  const res = await redfishFetch(actionUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: authHeader(creds) },
+    body: JSON.stringify(payload)
+  });
+  const body = await readResponseBody(res);
+  if (res.status >= 400) {
+    throw new RedfishError('InstallFromRepository failed', res.status, body);
+  }
+  const taskLocation = resolveLocation(baseUrl, res.headers.get('location'));
+  return { status: res.status, body, taskLocation, jobLocation: taskLocation };
+}
+
+export interface MultipartUpdateInput {
+  fileName: string;
+  fileStream: Readable;
+  size?: number;
+  updateParameters?: Record<string, unknown>;
+}
+
+async function computeFormLength(form: FormData): Promise<number | undefined> {
+  return new Promise((resolve, reject) => {
+    form.getLength((err, length) => {
+      if (err) {
+        if ('code' in (err as NodeJS.ErrnoException) && (err as NodeJS.ErrnoException).code === 'ERR_STREAM_PREMATURE_CLOSE') {
+          resolve(undefined);
+        } else {
+          reject(err);
+        }
+      } else {
+        resolve(length);
+      }
+    });
+  }).catch(() => undefined);
+}
+
+export async function multipartUpdate(idracHost: string, creds: IdracCreds, input: MultipartUpdateInput) {
+  const baseUrl = normalizeBaseUrl(idracHost);
+  const url = `${baseUrl}/redfish/v1/UpdateService/update-multipart`;
+  const form = new FormData();
+  form.append('UpdateParameters', JSON.stringify(input.updateParameters ?? {}), {
+    contentType: 'application/json'
+  });
+  form.append('UpdateFile', input.fileStream, {
+    filename: input.fileName,
+    contentType: 'application/octet-stream',
+    knownLength: input.size
+  });
+
+  const headers: Record<string, string> = {
+    ...form.getHeaders(),
+    authorization: authHeader(creds)
+  };
+
+  let length = typeof input.size === 'number' ? input.size : undefined;
+  if (length == null) {
+    length = await computeFormLength(form);
+  }
+  if (typeof length === 'number' && Number.isFinite(length)) {
+    headers['Content-Length'] = String(length);
+  }
+
+  const res = await redfishFetch(url, {
+    method: 'POST',
+    headers,
+    body: form as unknown as BodyInit
+  });
+  const body = await readResponseBody(res);
+  if (res.status >= 400) {
+    throw new RedfishError('Multipart update failed', res.status, body);
+  }
+  const taskLocation = resolveLocation(baseUrl, res.headers.get('location'));
+  return { status: res.status, body, taskLocation, jobLocation: taskLocation };
 }
 
 export async function getJob(jobLocation: string, creds: IdracCreds) {
-  const res = await fetch(jobLocation, { headers: { authorization: auth(creds) } });
+  const res = await redfishFetch(jobLocation, { headers: { authorization: authHeader(creds) } });
   if (!res.ok) throw new Error(`getJob failed: ${res.status}`);
   return res.json();
 }
@@ -33,8 +232,9 @@ export async function waitForJob(jobLocation: string, creds: IdracCreds, timeout
 }
 
 export async function softwareInventory(idracHost: string, creds: IdracCreds) {
-  const res = await fetch(`https://${idracHost}/redfish/v1/UpdateService/SoftwareInventory`, {
-    headers: { authorization: auth(creds) }
+  const baseUrl = normalizeBaseUrl(idracHost);
+  const res = await redfishFetch(`${baseUrl}/redfish/v1/UpdateService/SoftwareInventory`, {
+    headers: { authorization: authHeader(creds) }
   });
   if (!res.ok) throw new Error(`SoftwareInventory failed: ${res.status}`);
   return res.json();

--- a/api/src/lib/redfish/taskService.ts
+++ b/api/src/lib/redfish/taskService.ts
@@ -1,0 +1,348 @@
+import { authHeader, IdracCreds, normalizeBaseUrl, redfishFetch, resolveLocation, readResponseBody, RedfishError } from './client.js';
+
+const DEFAULT_TIMEOUT_MINUTES = Number(process.env.IDRAC_UPDATE_TIMEOUT_MIN ?? '90');
+const TERMINAL_STATES = new Set(['Completed', 'CompletedOK', 'CompletedWithWarnings', 'Cancelled', 'Exception', 'Killed', 'Failed']);
+const FAILURE_STATES = new Set(['Exception', 'Cancelled', 'Killed', 'Failed']);
+const START_BACKOFF_MS = 2000;
+const MAX_BACKOFF_MS = 15_000;
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+export interface TaskLogEvent {
+  type: 'poll' | 'retry' | 'complete' | 'wait-idrac' | 'idrac-online' | 'error';
+  timestamp: number;
+  state?: string;
+  status?: string;
+  progress?: number;
+  backoffMs?: number;
+  message?: string;
+}
+
+export type TaskLogger = (event: TaskLogEvent) => void | Promise<void>;
+
+export interface InventoryComponent {
+  id: string;
+  name?: string;
+  version?: string;
+  uri?: string;
+  raw?: any;
+}
+
+export interface InventorySnapshot {
+  raw: any;
+  components: Record<string, InventoryComponent>;
+}
+
+export interface InventoryChange {
+  id: string;
+  name?: string;
+  previousVersion?: string;
+  currentVersion?: string;
+  changeType: 'added' | 'removed' | 'updated';
+}
+
+export interface TaskPollResult {
+  task: any;
+  taskLocation: string;
+  state: string;
+  status?: string;
+  completed: boolean;
+  messages: string[];
+  oemDell?: unknown;
+  percentComplete?: number;
+  durationMs: number;
+  inventory?: {
+    before?: InventorySnapshot;
+    after: InventorySnapshot;
+    changes: InventoryChange[];
+  };
+}
+
+export interface PollTaskOptions {
+  idracHost: string;
+  creds: IdracCreds;
+  taskLocation?: string | null;
+  baselineInventory?: InventorySnapshot;
+  logger?: TaskLogger;
+  timeoutMinutes?: number;
+}
+
+export async function pollTask(options: PollTaskOptions): Promise<TaskPollResult> {
+  const baseUrl = normalizeBaseUrl(options.idracHost);
+  const resolvedLocation = options.taskLocation ? resolveLocation(baseUrl, options.taskLocation) ?? options.taskLocation : null;
+  if (!resolvedLocation) {
+    throw new Error('Task location not provided by Redfish response');
+  }
+
+  const timeoutMinutes = options.timeoutMinutes ?? DEFAULT_TIMEOUT_MINUTES;
+  const deadline = Date.now() + timeoutMinutes * 60_000;
+  const logger = options.logger;
+  const startedAt = Date.now();
+
+  let beforeInventory = options.baselineInventory;
+  if (!beforeInventory) {
+    try {
+      beforeInventory = await collectSoftwareInventory(baseUrl, options.creds);
+    } catch (error) {
+      logger?.({
+        type: 'error',
+        timestamp: Date.now(),
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  let backoff = START_BACKOFF_MS;
+  let finalTask: any | null = null;
+  let state = '';
+  let status = '';
+  let percentComplete: number | undefined;
+  let messages: string[] = [];
+  let oemDell: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      const res = await redfishFetch(resolvedLocation, {
+        headers: { authorization: authHeader(options.creds) }
+      });
+
+      if (!res.ok) {
+        const body = await readResponseBody(res);
+        if (res.status >= 500 || res.status === 404) {
+          logger?.({ type: 'retry', timestamp: Date.now(), message: `Transient response ${res.status}`, backoffMs: backoff });
+          await sleep(backoff);
+          backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+          continue;
+        }
+        throw new RedfishError('Task poll failed', res.status, body);
+      }
+
+      const task = await res.json();
+      state = String(task.TaskState ?? task.JobState ?? task.Status ?? '');
+      status = String(task.TaskStatus ?? task.Status ?? '');
+      percentComplete = typeof task.PercentComplete === 'number' ? task.PercentComplete : percentComplete;
+      messages = Array.isArray(task.Messages)
+        ? task.Messages.map((m: any) => m?.Message ?? m?.MessageId ?? m?.Resolution ?? JSON.stringify(m))
+        : messages;
+      oemDell = task?.Oem?.Dell ?? oemDell;
+
+      await Promise.resolve(logger?.({
+        type: 'poll',
+        timestamp: Date.now(),
+        state,
+        status,
+        progress: percentComplete,
+        backoffMs: backoff
+      }));
+
+      if (TERMINAL_STATES.has(state)) {
+        finalTask = task;
+        break;
+      }
+
+      await sleep(backoff);
+      backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+    } catch (error) {
+      if (shouldRetry(error)) {
+        await Promise.resolve(logger?.({
+          type: 'retry',
+          timestamp: Date.now(),
+          message: error instanceof Error ? error.message : String(error),
+          backoffMs: backoff
+        }));
+        await sleep(backoff);
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+        continue;
+      }
+
+      await Promise.resolve(logger?.({
+        type: 'error',
+        timestamp: Date.now(),
+        message: error instanceof Error ? error.message : String(error)
+      }));
+      throw error;
+    }
+  }
+
+  if (!finalTask) {
+    throw new Error('Timed out waiting for Redfish task completion');
+  }
+
+  await Promise.resolve(logger?.({ type: 'complete', timestamp: Date.now(), state, status }));
+
+  const completedSuccessfully = !FAILURE_STATES.has(state) && !/Exception|Error|Failed/i.test(status);
+
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) throw new Error('Timed out before iDRAC recovery phase');
+
+  await waitForIdracServiceRoot(baseUrl, options.creds, deadline, logger);
+
+  let afterInventory: InventorySnapshot | undefined;
+  try {
+    afterInventory = await collectSoftwareInventory(baseUrl, options.creds);
+  } catch (error) {
+    await Promise.resolve(logger?.({
+      type: 'error',
+      timestamp: Date.now(),
+      message: error instanceof Error ? error.message : String(error)
+    }));
+  }
+
+  const changes = afterInventory ? diffInventories(beforeInventory, afterInventory) : [];
+  return {
+    task: finalTask,
+    taskLocation: resolvedLocation,
+    state,
+    status,
+    completed: completedSuccessfully,
+    messages,
+    oemDell,
+    percentComplete,
+    durationMs: Date.now() - startedAt,
+    inventory: afterInventory
+      ? {
+          before: beforeInventory,
+          after: afterInventory,
+          changes
+        }
+      : undefined
+  };
+}
+
+async function waitForIdracServiceRoot(baseUrl: string, creds: IdracCreds, deadline: number, logger?: TaskLogger) {
+  const url = `${baseUrl}/redfish/v1/`;
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    try {
+      const res = await redfishFetch(url, {
+        headers: { authorization: authHeader(creds) },
+        signal: controller.signal
+      });
+      clearTimeout(timeout);
+      if (res.ok) {
+        await Promise.resolve(logger?.({ type: 'idrac-online', timestamp: Date.now() }));
+        return;
+      }
+      if (res.status >= 500) {
+        await Promise.resolve(
+          logger?.({ type: 'retry', timestamp: Date.now(), message: `Service root ${res.status}`, backoffMs: START_BACKOFF_MS })
+        );
+      } else {
+        const body = await readResponseBody(res);
+        throw new RedfishError('Unexpected response while waiting for iDRAC service root', res.status, body);
+      }
+    } catch (error) {
+      clearTimeout(timeout);
+      if (!shouldRetry(error)) throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    await Promise.resolve(
+      logger?.({ type: 'wait-idrac', timestamp: Date.now(), backoffMs: Math.min(5000, START_BACKOFF_MS * (attempt + 1)) })
+    );
+    await sleep(Math.min(5000, START_BACKOFF_MS * Math.pow(1.5, attempt++)));
+  }
+  throw new Error('Timed out waiting for iDRAC to return after update');
+}
+
+export async function collectSoftwareInventory(baseUrl: string, creds: IdracCreds): Promise<InventorySnapshot> {
+  const url = `${baseUrl}/redfish/v1/UpdateService/SoftwareInventory`;
+  const res = await redfishFetch(url, { headers: { authorization: authHeader(creds) } });
+  if (!res.ok) {
+    const body = await readResponseBody(res);
+    throw new RedfishError('Failed to read SoftwareInventory', res.status, body);
+  }
+
+  const data = await res.json();
+  const members = Array.isArray(data?.Members) ? data.Members : [];
+  const components: Record<string, InventoryComponent> = {};
+  const seen = new Set<string>();
+
+  for (const member of members) {
+    const memberUri = typeof member === 'string' ? member : member?.['@odata.id'] ?? member?.MemberId ?? member?.Id;
+    if (!memberUri) continue;
+    const absolute = resolveLocation(baseUrl, typeof member === 'string' ? member : member?.['@odata.id'] ?? null) ?? memberUri;
+    if (seen.has(absolute)) continue;
+    seen.add(absolute);
+    try {
+      const compRes = await redfishFetch(absolute, { headers: { authorization: authHeader(creds) } });
+      if (!compRes.ok) continue;
+      const detail = await compRes.json();
+      const id = String(detail?.Id ?? detail?.ComponentID ?? detail?.MemberId ?? absolute);
+      components[id] = {
+        id,
+        name: detail?.Name ?? detail?.Description ?? detail?.ComponentName ?? id,
+        version: detail?.Version ?? detail?.FirmwareVersion ?? detail?.SoftwareVersion ?? detail?.Build ?? detail?.CurrentVersion,
+        uri: absolute,
+        raw: detail
+      };
+    } catch {
+      // ignore individual component failures
+    }
+  }
+
+  return { raw: data, components };
+}
+
+export function diffInventories(before?: InventorySnapshot, after?: InventorySnapshot): InventoryChange[] {
+  const beforeMap = before?.components ?? {};
+  const afterMap = after?.components ?? {};
+  const keys = new Set([...Object.keys(beforeMap), ...Object.keys(afterMap)]);
+  const changes: InventoryChange[] = [];
+
+  for (const key of keys) {
+    const prev = beforeMap[key];
+    const next = afterMap[key];
+    if (!next) {
+      changes.push({
+        id: prev?.id ?? key,
+        name: prev?.name,
+        previousVersion: prev?.version,
+        currentVersion: undefined,
+        changeType: 'removed'
+      });
+      continue;
+    }
+    if (!prev) {
+      changes.push({
+        id: next.id,
+        name: next.name,
+        previousVersion: undefined,
+        currentVersion: next.version,
+        changeType: 'added'
+      });
+      continue;
+    }
+    if (prev.version !== next.version) {
+      changes.push({
+        id: next.id,
+        name: next.name ?? prev.name,
+        previousVersion: prev.version,
+        currentVersion: next.version,
+        changeType: 'updated'
+      });
+    }
+  }
+
+  return changes.sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function shouldRetry(error: unknown): boolean {
+  if (error instanceof RedfishError) {
+    return error.status >= 500 || error.status === 404;
+  }
+  if (error && typeof error === 'object') {
+    const err = error as NodeJS.ErrnoException;
+    if (typeof err.code === 'string' && ['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EHOSTUNREACH', 'ENETUNREACH'].includes(err.code)) {
+      return true;
+    }
+  }
+  if (error instanceof Error) {
+    const msg = error.message || '';
+    return /(ECONNRESET|ECONNREFUSED|ETIMEDOUT|fetch failed|network|socket hang up)/i.test(msg);
+  }
+  return false;
+}

--- a/api/src/routes/hosts.ts
+++ b/api/src/routes/hosts.ts
@@ -3,6 +3,7 @@ import db from '../db/index.js';
 import { hosts } from '../db/schema.js';
 import { eq } from 'drizzle-orm';
 import { detectCapabilities } from '../lib/detect.js';
+import { redfishFetch } from '../lib/redfish/client.js';
 
 export default async function hostsRoutes(app: FastifyInstance) {
   app.post('/hosts', async (request) => {
@@ -30,7 +31,7 @@ export default async function hostsRoutes(app: FastifyInstance) {
 
     const res = await detectCapabilities({
       redfish: async () => {
-        try { const r = await fetch(`https://${row.mgmtIp}/redfish/v1/`); return r.ok; } catch { return false; }
+        try { const r = await redfishFetch(`https://${row.mgmtIp}/redfish/v1/`); return r.ok; } catch { return false; }
       },
       wsman: async () => false,
       racadm: async () => false

--- a/api/src/routes/uploads.ts
+++ b/api/src/routes/uploads.ts
@@ -1,0 +1,29 @@
+import { FastifyInstance } from 'fastify';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+const DEFAULT_UPLOAD_DIR = process.env.FIRMWARE_UPLOAD_DIR || path.join(process.cwd(), 'uploads');
+
+function safeFileName(name: string) {
+  return name.replace(/[^a-zA-Z0-9_.-]/g, '_');
+}
+
+export default async function uploadsRoutes(app: FastifyInstance) {
+  app.post('/uploads/firmware', async (request, reply) => {
+    const file = await (request as any).file();
+    if (!file) {
+      reply.code(400).send({ error: 'missing_file' });
+      return;
+    }
+
+    await fs.promises.mkdir(DEFAULT_UPLOAD_DIR, { recursive: true });
+    const filename = `${Date.now()}-${safeFileName(file.filename || 'firmware.bin')}`;
+    const targetPath = path.join(DEFAULT_UPLOAD_DIR, filename);
+
+    await pipeline(file.file, fs.createWriteStream(targetPath));
+    const uri = `file://${targetPath}`;
+
+    return { ok: true, path: targetPath, uri, filename };
+  });
+}

--- a/src/components/scheduler/EnhancedCommandControl.tsx
+++ b/src/components/scheduler/EnhancedCommandControl.tsx
@@ -15,6 +15,7 @@ import { CampaignFilters, type CampaignFilters as CampaignFiltersType } from "./
 import { CampaignDetailsModal } from "./CampaignDetailsModal";
 import { CampaignTemplatesModal } from "./CampaignTemplatesModal";
 import { BulkCampaignActions } from "./BulkCampaignActions";
+import { ManualUpdatePanel } from "../updates/ManualUpdatePanel";
 import { supabase } from "@/integrations/supabase/client";
 import { 
   Settings,
@@ -516,9 +517,10 @@ export function EnhancedCommandControl() {
       </div>
 
       <Tabs value={tab} onValueChange={setTab} className="space-y-6">
-        <TabsList>
+        <TabsList className="flex flex-wrap gap-2">
           <TabsTrigger value="campaigns">Update Campaigns</TabsTrigger>
           <TabsTrigger value="emergency">Emergency Actions</TabsTrigger>
+          <TabsTrigger value="manual-update">Manual Update</TabsTrigger>
         </TabsList>
 
         <TabsContent value="campaigns" className="space-y-6">
@@ -653,8 +655,8 @@ export function EnhancedCommandControl() {
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Button 
-                  variant="destructive" 
+                <Button
+                  variant="destructive"
                   className="h-auto p-4"
                   onClick={() => handleEmergencyAction('security_patch')}
                 >
@@ -664,8 +666,8 @@ export function EnhancedCommandControl() {
                     <div className="text-xs opacity-90">Critical vulnerability patching</div>
                   </div>
                 </Button>
-                <Button 
-                  variant="outline" 
+                <Button
+                  variant="outline"
                   className="h-auto p-4"
                   onClick={() => handleEmergencyAction('idrac_update')}
                 >
@@ -678,6 +680,9 @@ export function EnhancedCommandControl() {
               </div>
             </CardContent>
           </Card>
+        </TabsContent>
+        <TabsContent value="manual-update" className="space-y-6">
+          <ManualUpdatePanel />
         </TabsContent>
       </Tabs>
 

--- a/src/components/updates/ManualUpdatePanel.tsx
+++ b/src/components/updates/ManualUpdatePanel.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useToast } from '@/hooks/use-toast';
+import { createPlan, getPlanStatus, listHosts, startPlan, uploadFirmwareFile } from '@/lib/api';
+import type { PlanPayload } from '@/lib/api';
+import { Loader2, Server, UploadCloud } from 'lucide-react';
+
+const DEFAULT_CATALOG = 'https://downloads.dell.com/catalog/Catalog.xml.gz';
+
+export type UpdateMode = 'LATEST_FROM_CATALOG' | 'SPECIFIC_URL' | 'MULTIPART_FILE';
+
+interface HostRow {
+  id: string;
+  fqdn: string;
+  mgmtIp: string;
+  model?: string | null;
+  serviceTag?: string | null;
+}
+
+interface HostRunCtx {
+  progress?: any;
+  results?: any[];
+  error?: { message?: string };
+  finalInventory?: any;
+}
+
+interface HostRun {
+  id: string;
+  hostId: string;
+  state: string;
+  ctx: HostRunCtx;
+  updatedAt?: string;
+}
+
+interface PlanStatus {
+  id: string;
+  hosts: HostRun[];
+}
+
+function parseTargets(raw: string): string[] | undefined {
+  const entries = raw
+    .split(/\r?\n|,/)
+    .map(v => v.trim())
+    .filter(Boolean);
+  return entries.length ? entries : undefined;
+}
+
+export function ManualUpdatePanel() {
+  const [hosts, setHosts] = useState<HostRow[]>([]);
+  const [selectedHosts, setSelectedHosts] = useState<string[]>([]);
+  const [mode, setMode] = useState<UpdateMode>('SPECIFIC_URL');
+  const [catalogUrl, setCatalogUrl] = useState<string>(DEFAULT_CATALOG);
+  const [imageUrl, setImageUrl] = useState('');
+  const [multipartUrl, setMultipartUrl] = useState('');
+  const [multipartFile, setMultipartFile] = useState<File | null>(null);
+  const [targetsText, setTargetsText] = useState('');
+  const [loadingHosts, setLoadingHosts] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [activePlanId, setActivePlanId] = useState<string | null>(null);
+  const [planStatus, setPlanStatus] = useState<PlanStatus | null>(null);
+  const [polling, setPolling] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const fetchHosts = async () => {
+      try {
+        setLoadingHosts(true);
+        const data = await listHosts();
+        setHosts(data);
+      } catch (error) {
+        toast({ title: 'Failed to load hosts', description: (error as Error).message, variant: 'destructive' });
+      } finally {
+        setLoadingHosts(false);
+      }
+    };
+    fetchHosts();
+  }, [toast]);
+
+  useEffect(() => {
+    if (!activePlanId) return;
+    let cancelled = false;
+    let timer: NodeJS.Timeout;
+
+    const poll = async () => {
+      try {
+        const status = await getPlanStatus(activePlanId);
+        if (!cancelled) {
+          setPlanStatus(status as PlanStatus);
+          const allDone = (status.hosts || []).every((run: HostRun) => run.state === 'DONE' || run.state === 'ERROR');
+          if (!allDone) {
+            timer = setTimeout(poll, 5000);
+          } else {
+            setPolling(false);
+          }
+        }
+      } catch (error) {
+        if (!cancelled) {
+          toast({ title: 'Failed to poll plan status', description: (error as Error).message, variant: 'destructive' });
+          setPolling(false);
+        }
+      }
+    };
+
+    setPolling(true);
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [activePlanId, toast]);
+
+  const hostMap = useMemo(() => {
+    return hosts.reduce<Record<string, HostRow>>((acc, host) => {
+      acc[host.id] = host;
+      return acc;
+    }, {});
+  }, [hosts]);
+
+  const handleHostToggle = (id: string) => {
+    setSelectedHosts(prev => (prev.includes(id) ? prev.filter(h => h !== id) : [...prev, id]));
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedHosts.length) {
+      toast({ title: 'Select hosts', description: 'Choose at least one host to update.', variant: 'destructive' });
+      return;
+    }
+
+    if (mode === 'SPECIFIC_URL' && !imageUrl) {
+      toast({ title: 'Image URL required', description: 'Provide a firmware image URL for SimpleUpdate.', variant: 'destructive' });
+      return;
+    }
+
+    if (mode === 'MULTIPART_FILE' && !multipartFile && !multipartUrl) {
+      toast({ title: 'Provide firmware file', description: 'Upload a firmware file or provide a downloadable URL.', variant: 'destructive' });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const artifacts: PlanPayload['artifacts'] = [];
+      if (mode === 'SPECIFIC_URL') {
+        artifacts.push({ component: 'Firmware', imageUri: imageUrl });
+      } else if (mode === 'MULTIPART_FILE') {
+        if (multipartFile) {
+          const upload = await uploadFirmwareFile(multipartFile);
+          artifacts.push({ component: 'Firmware', imageUri: upload.uri });
+        } else if (multipartUrl) {
+          artifacts.push({ component: 'Firmware', imageUri: multipartUrl });
+        }
+      }
+
+      const policy: Record<string, unknown> = {
+        updateMode: mode,
+        catalogUrl,
+        targets: parseTargets(targetsText)
+      };
+
+      const payload: PlanPayload = {
+        name: `manual-${mode.toLowerCase()}-${Date.now()}`,
+        targets: selectedHosts,
+        artifacts,
+        policy
+      };
+
+      const plan = await createPlan(payload);
+      await startPlan(plan.id);
+      toast({ title: 'Update started', description: 'Plan queued for selected hosts.' });
+      setActivePlanId(plan.id);
+      setPlanStatus(null);
+    } catch (error) {
+      toast({ title: 'Failed to start update', description: (error as Error).message, variant: 'destructive' });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const renderProgress = (run: HostRun) => {
+    const host = hostMap[run.hostId];
+    const progress = run.ctx?.progress;
+    const phase = progress?.phase ?? 'N/A';
+    const message = progress?.message ?? '';
+    return (
+      <Card key={run.id} className="bg-muted/40">
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium flex items-center gap-2">
+            <Server className="h-4 w-4" />
+            {host?.fqdn || host?.mgmtIp || run.hostId}
+          </CardTitle>
+          <Badge variant={run.state === 'DONE' ? 'success' : run.state === 'ERROR' ? 'destructive' : 'secondary'}>
+            {run.state}
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline">Phase: {phase}</Badge>
+            {progress?.taskLocation && <Badge variant="outline">Task: {progress.taskLocation}</Badge>}
+            {message && <span className="text-muted-foreground">{message}</span>}
+          </div>
+          {progress?.event?.type && (
+            <div className="text-xs text-muted-foreground">
+              Last event: {progress.event.type}{progress.event.state ? ` · ${progress.event.state}` : ''}
+              {progress.event.status ? ` · ${progress.event.status}` : ''}
+            </div>
+          )}
+          {run.ctx?.results?.length ? (
+            <div className="space-y-1">
+              <div className="text-xs font-semibold text-muted-foreground">Results</div>
+              <ul className="text-xs space-y-1">
+                {run.ctx.results.map((result, idx) => {
+                  const label = result.component || result.mode || `Result ${idx + 1}`;
+                  const state = result.task?.state || result.racadm?.success === false ? 'ERROR' : result.task?.state || 'DONE';
+                  return (
+                    <li key={idx} className="flex items-center justify-between">
+                      <span>{label}</span>
+                      <Badge variant={state === 'Completed' || state === 'DONE' ? 'success' : state === 'ERROR' ? 'destructive' : 'secondary'}>
+                        {result.task?.status || result.racadm?.successMessage || state}
+                      </Badge>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          ) : null}
+          {run.ctx?.error?.message && (
+            <Alert variant="destructive">
+              <AlertDescription>{run.ctx.error.message}</AlertDescription>
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Manual Firmware Update</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <section className="space-y-3">
+            <Label className="text-sm font-medium">Select Hosts</Label>
+            <ScrollArea className="h-48 border rounded-md p-3">
+              {loadingHosts ? (
+                <div className="flex items-center justify-center h-full text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" /> Loading hosts...
+                </div>
+              ) : hosts.length ? (
+                <div className="grid gap-2">
+                  {hosts.map(host => (
+                    <label key={host.id} className="flex items-center gap-3 text-sm">
+                      <Checkbox checked={selectedHosts.includes(host.id)} onCheckedChange={() => handleHostToggle(host.id)} />
+                      <div>
+                        <div className="font-medium">{host.fqdn || host.mgmtIp}</div>
+                        <div className="text-xs text-muted-foreground">{host.mgmtIp} {host.model ? `· ${host.model}` : ''}</div>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-sm text-muted-foreground">No hosts registered.</div>
+              )}
+            </ScrollArea>
+          </section>
+
+          <section className="space-y-3">
+            <Label className="text-sm font-medium">Update Mode</Label>
+            <RadioGroup value={mode} onValueChange={value => setMode(value as UpdateMode)} className="grid gap-2">
+              <div className="flex items-start gap-3 rounded-md border p-3">
+                <RadioGroupItem value="LATEST_FROM_CATALOG" id="mode-catalog" />
+                <div className="space-y-1">
+                  <Label htmlFor="mode-catalog">Latest from Dell Catalog</Label>
+                  <p className="text-xs text-muted-foreground">Fetches the latest supported firmware directly from the Dell online catalog.</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-md border p-3">
+                <RadioGroupItem value="SPECIFIC_URL" id="mode-url" />
+                <div className="space-y-1">
+                  <Label htmlFor="mode-url">Specific package by URL</Label>
+                  <p className="text-xs text-muted-foreground">Provide a direct download URL accessible by iDRAC.</p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3 rounded-md border p-3">
+                <RadioGroupItem value="MULTIPART_FILE" id="mode-file" />
+                <div className="space-y-1">
+                  <Label htmlFor="mode-file">Upload firmware file</Label>
+                  <p className="text-xs text-muted-foreground">Push a local firmware package using Redfish multipart upload.</p>
+                </div>
+              </div>
+            </RadioGroup>
+          </section>
+
+          {mode === 'LATEST_FROM_CATALOG' && (
+            <section className="space-y-2">
+              <Label htmlFor="catalog-url">Catalog URL</Label>
+              <Input id="catalog-url" value={catalogUrl} onChange={e => setCatalogUrl(e.target.value)} placeholder={DEFAULT_CATALOG} />
+            </section>
+          )}
+
+          {mode === 'SPECIFIC_URL' && (
+            <section className="space-y-2">
+              <Label htmlFor="image-url">Firmware Image URL</Label>
+              <Input id="image-url" value={imageUrl} onChange={e => setImageUrl(e.target.value)} placeholder="https://.../firmware.exe" />
+            </section>
+          )}
+
+          {mode === 'MULTIPART_FILE' && (
+            <section className="grid gap-2">
+              <Label>Firmware File</Label>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <Input type="file" accept=".exe,.bin,.iso,.img,.zip" onChange={e => setMultipartFile(e.target.files?.[0] ?? null)} />
+                <div className="text-xs text-muted-foreground flex items-center gap-1">
+                  <UploadCloud className="h-4 w-4" /> Optional: provide a downloadable URL instead of uploading a file.
+                </div>
+              </div>
+              <Input value={multipartUrl} onChange={e => setMultipartUrl(e.target.value)} placeholder="https://.../firmware.exe (optional)" />
+            </section>
+          )}
+
+          <section className="space-y-2">
+            <Label htmlFor="targets">Optional Targets Override</Label>
+            <Textarea
+              id="targets"
+              value={targetsText}
+              onChange={e => setTargetsText(e.target.value)}
+              placeholder="Enter Redfish component URIs or IDs, separated by commas or new lines"
+            />
+            <p className="text-xs text-muted-foreground">Example: /redfish/v1/Systems/System.Embedded.1/Bios</p>
+          </section>
+
+          <div className="flex items-center gap-3">
+            <Button onClick={handleSubmit} disabled={submitting}>
+              {submitting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}Start Update
+            </Button>
+            {polling && <span className="text-xs text-muted-foreground">Polling plan progress...</span>}
+          </div>
+        </CardContent>
+      </Card>
+
+      {planStatus && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Update Progress</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="text-sm text-muted-foreground">Plan ID: {planStatus.id}</div>
+            <div className="grid gap-3">
+              {planStatus.hosts.map(renderProgress)}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -51,6 +51,22 @@ export async function createPlan(payload: PlanPayload) {
   return res.json();
 }
 
+export const startPlan = (id: string) => apiSend<{ started: boolean; count: number }>(`/plans/${id}/start`, 'POST');
+
+export async function uploadFirmwareFile(file: File) {
+  const formData = new FormData();
+  formData.append('firmware', file);
+  const res = await fetch(`${API_BASE_URL}/uploads/firmware`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: formData
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json() as Promise<{ ok: boolean; path: string; uri: string; filename: string }>;
+}
+
 export async function discoverHost(id: string) {
   const res = await fetch(`${API_BASE_URL}/hosts/${id}/discover`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- harden the Redfish client with configurable TLS agents, repository installs, and multipart upload helpers
- introduce a resilient task poller and RACADM fallback in the orchestration state machine
- add a firmware upload API, manual update UI tab, and document update modes, configuration, and environment variables

## Testing
- npm run lint *(fails: repository contains pre-existing lint violations across api/server/ui packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c9910b1b48832095589ec8fba31a2a